### PR TITLE
Fix of empty leaves issue in MT building and adding a flag to force MT building on one GPU even in multi-GPU systems

### DIFF
--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -23,7 +23,7 @@ rand = { workspace = true, features = ["getrandom"] }
 serde = { workspace = true, features = ["alloc"] }
 static_assertions = { workspace = true }
 unroll = { workspace = true }
-cryptography_cuda ={path="../depends/cryptography_cuda", optional=true}
+cryptography_cuda = { path = "../depends/cryptography_cuda", optional = true}
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }
@@ -40,8 +40,6 @@ default = []
 cuda = ["cryptography_cuda/cuda"]
 precompile = []
 no_cuda = ["cryptography_cuda/no_cuda"]
-
-
 
 # Display math equations properly in documentation
 [package.metadata.docs.rs]

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [features]
-default = ["gate_testing", "parallel", "rand_chacha", "std", "timing"]
+default = ["gate_testing", "parallel", "rand_chacha", "std"]
 gate_testing = []
 parallel = ["hashbrown/rayon", "plonky2_maybe_rayon/parallel"]
 std = ["anyhow/std", "rand/std", "itertools/use_std"]
@@ -42,7 +42,7 @@ once_cell = { version = "1.18.0" }
 plonky2_field = { version = "0.2.0", path = "../field", default-features = false }
 plonky2_maybe_rayon = { version = "0.2.0", path = "../maybe_rayon", default-features = false }
 plonky2_util = { version = "0.2.0", path = "../util", default-features = false }
-cryptography_cuda ={path="../depends/cryptography_cuda", optional=true}
+cryptography_cuda ={ path = "../depends/cryptography_cuda", optional = true}
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", default-features = false, features = ["js"] }

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -760,7 +760,16 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
 
     pub fn new_from_2d(leaves_2d: Vec<Vec<F>>, cap_height: usize) -> Self {
         let leaf_size = leaves_2d[0].len();
-        let leaves_1d = leaves_2d.into_iter().flatten().collect();
+        let leaves_count = leaves_2d.len();
+        let zeros = vec![F::from_canonical_u64(0); leaf_size];
+        let mut leaves_1d: Vec<F> = Vec::with_capacity(leaves_count * leaf_size);
+        for idx in 0..leaves_count {
+            if leaves_2d[idx].len() == 0 {
+                leaves_1d.extend(zeros.clone());
+            } else {
+                leaves_1d.extend(leaves_2d[idx].clone());
+            }
+        }
         Self::new_from_1d(leaves_1d, leaf_size, cap_height)
     }
 

--- a/plonky2/src/util/timing.rs
+++ b/plonky2/src/util/timing.rs
@@ -1,6 +1,7 @@
 use log::Level;
 #[cfg(feature = "timing")]
 use web_time::{Duration, Instant};
+#[cfg(not(feature = "timing"))]
 use log::log;
 
 /// The hierarchy of scopes, and the time consumed by each one. Useful for profiling.

--- a/plonky2/src/util/timing.rs
+++ b/plonky2/src/util/timing.rs
@@ -1,6 +1,7 @@
 use log::Level;
 #[cfg(feature = "timing")]
 use web_time::{Duration, Instant};
+use log::log;
 
 /// The hierarchy of scopes, and the time consumed by each one. Useful for profiling.
 #[cfg(feature = "timing")]


### PR DESCRIPTION
1. In new_from_leaves_2d(), we performed a flattening of the 2D Vec<Vec<F>> into 1D Vec<F>. However, if some inner Vec<F> is empty, the final number of leaves in the 1D array is wrong. We fixed this by adding F::ZERO when the leaf is empty.
2. We add a  FORCE_SINGLE_GPU flag to force building the MT on a single GPU even if NUM_OF_GPUS is > 1.